### PR TITLE
Importing as `resolver` is deprecated

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -44,7 +44,8 @@ module.exports = function (broccoli) {
   var applicationJs = compileES6(appAndDependencies, {
     loaderFile: 'loader.js',
     ignoredModules: [
-      'resolver'
+      'resolver',
+      'ember/resolver'
     ],
     inputFiles: [
       'appkit/**/*.js'

--- a/app/app.js
+++ b/app/app.js
@@ -1,4 +1,4 @@
-import Resolver from 'resolver';
+import Resolver from 'ember/resolver';
 
 var App = Ember.Application.extend({
   LOG_ACTIVE_GENERATION: true,


### PR DESCRIPTION
See for more info:
https://github.com/stefanpenner/ember-jj-abrams-resolver/pull/27
