### PR TITLE
Importing EAR as `resolver` is deprecated part 2

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -44,7 +44,6 @@ module.exports = function (broccoli) {
   var applicationJs = compileES6(appAndDependencies, {
     loaderFile: 'loader.js',
     ignoredModules: [
-      'resolver',
       'ember/resolver'
     ],
     inputFiles: [

--- a/tests/helpers/isolated_container.js
+++ b/tests/helpers/isolated_container.js
@@ -1,4 +1,4 @@
-import Resolver from 'resolver';
+import Resolver from 'ember/resolver';
 
 function isolatedContainer(fullNames) {
   var container = new Ember.Container();


### PR DESCRIPTION
Sorry, missed the tests :smiley: 
