### PR TITLE
Add .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
Addresses #7.

`.bowerrc` provides an explicit directory outside of `app/` for Bower dependencies to be installed into.