### PR TITLE
Readme link to original repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Broccoli Sample App
 
-Sample Ember app for [Broccoli](https://github.com/joliss/broccoli).
+Sample Ember app for [Broccoli](https://github.com/broccolijs/broccoli).
 
 See [Brocfile.js](/Brocfile.js) for the build definition.
 


### PR DESCRIPTION
Changed `README.md` link to original Broccoli repo, rather than a fork.
